### PR TITLE
aom: enable install from head

### DIFF
--- a/Formula/a/aom.rb
+++ b/Formula/a/aom.rb
@@ -5,6 +5,7 @@ class Aom < Formula
       tag:      "v3.12.1",
       revision: "10aece4157eb79315da205f39e19bf6ab3ee30d0"
   license "BSD-2-Clause"
+  head "https://aomedia.googlesource.com/aom.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7187a5accf9da7614d96b6fb07df1c0b144cfb096d920e9936fa78b6fba18c4a"


### PR DESCRIPTION
I noticed aom didn't have a way to install from head, so this formula change allows it so.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
